### PR TITLE
Fabiangosebrink/fixing config

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -119,7 +119,7 @@
         }
       }
     },
-    "@fidx/lib-to-configure": {
+    "fidx-lib-to-configure": {
       "projectType": "library",
       "root": "projects/fidx/lib-to-configure",
       "sourceRoot": "projects/fidx/lib-to-configure/src",
@@ -158,7 +158,8 @@
     }
   },
   "cli": {
-    "defaultCollection": "@angular-eslint/schematics"
+    "defaultCollection": "@angular-eslint/schematics",
+    "analytics": "8d80b633-02f1-4d8d-aeaa-4bf65689e581"
   },
   "defaultProject": "test-app"
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build-lib": "ng build fidx-lib-to-configure",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/projects/fidx/lib-to-configure/src/lib/lib-to-configure.component.ts
+++ b/projects/fidx/lib-to-configure/src/lib/lib-to-configure.component.ts
@@ -3,7 +3,7 @@ import { LibConfigurationProvider } from './lib-configuration';
 
 @Component({
   selector: 'fidx-lib-to-configure',
-  template: `<p>lib-to-configure works!</p>
+  template: `<p>lib-to-configure works with {{configurationProvider.config | json}}</p>
 `,
   styles: [
   ]
@@ -17,5 +17,4 @@ export class LibToConfigureComponent implements OnInit {
   ngOnInit(): void {
     console.log(this.configurationProvider.config);
   }
-
 }

--- a/projects/test-app/src/app/app.module.ts
+++ b/projects/test-app/src/app/app.module.ts
@@ -2,7 +2,7 @@
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { APP_INITIALIZER, Injectable, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { LibConfigurationProvider, LibToConfigureConfiguration, LibToConfigureModule } from 'projects/fidx/lib-to-configure/src/public-api';
+import { LibConfigurationProvider, LibToConfigureConfiguration, LibToConfigureModule } from '@fidx/lib-to-configure';
 import { AppComponent } from './app.component';
 
 @Injectable({ providedIn: 'root' })

--- a/projects/test-app/src/app/app.module.ts
+++ b/projects/test-app/src/app/app.module.ts
@@ -1,9 +1,9 @@
 /* eslint-disable arrow-body-style */
-import { APP_INITIALIZER, Injectable, NgModule } from '@angular/core';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { APP_INITIALIZER, Injectable, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { LibConfigurationProvider, LibToConfigureConfiguration, LibToConfigureModule } from 'projects/fidx/lib-to-configure/src/public-api';
 import { AppComponent } from './app.component';
-import { LibToConfigureModule, LibConfigurationProvider, LibToConfigureConfiguration } from 'projects/fidx/lib-to-configure/src/public-api';
 
 @Injectable({ providedIn: 'root' })
 export class ConfigurationStore {
@@ -18,6 +18,7 @@ export class ConfigurationStore {
   }
 }
 
+@Injectable({ providedIn: 'root' })
 export class ConfigFromApp implements LibConfigurationProvider {
   constructor(private configStore: ConfigurationStore) {}
 


### PR DESCRIPTION
The solution for your problem was a missing `@Injectable({ providedIn: 'root' })` above the `ConfigFromApp`. Without the `@Injectable()` nothing can be injected.

I also fixed: 

- build task to build lib (Without it, the imports do not work correctly)
- fixed the imports to be to the `@fidx/lib-to-configure` path. NEVER go to the `projects/...` folder
- name of the project in angular json should be without `@` and slashes. It is a name of the lib, not the path or import path
- I would delete the setTimeout. Basically this technical solution is just an exchange of the provider of the config during runtime. make it as fast as possible :-)

